### PR TITLE
docs: add DEVELOPER.md and DOCKER.md

### DIFF
--- a/.idea/runConfigurations/OengusApplicationTemplate.xml
+++ b/.idea/runConfigurations/OengusApplicationTemplate.xml
@@ -1,0 +1,34 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="OengusApplicationTemplate" type="Application" factoryName="Application">
+    <envs>
+      <env name="JWT_SECRET" value="&lt;random string&gt;" />
+      <env name="PAYPAL_CLIENT_ID" value="" />
+      <env name="DISCORD_CLIENT_ID" value="&lt;your Discord client ID goes here&gt;" />
+      <env name="DISCORD_CLIENT_SECRET" value="&lt;your Discord client secret goes here&gt;" />
+      <env name="DISCORD_BOT_TOKEN" value="" />
+      <env name="TWITCH_CLIENT_ID" value="" />
+      <env name="TWITCH_CLIENT_SECRET" value="" />
+      <env name="TWITTER_CONSUMER_KEY" value="" />
+      <env name="TWITTER_CONSUMER_SECRET" value="" />
+      <env name="TWITTER_ACCESS_TOKEN" value="" />
+      <env name="TWITTER_ACCESS_TOKEN_SECRET" value="" />
+      <env name="twitter4j.debug" value="true" />
+      <env name="twitter4j.oauth.consumerKey" value="" />
+      <env name="twitter4j.oauth.consumerSecret" value="" />
+      <env name="TWITTER_OAUTH2_CLIENT_ID" value="" />
+      <env name="TWITTER_OAUTH2_CLIENT_SECRET" value="" />
+      <env name="DB_URL" value="jdbc:postgresql://localhost:5432/oengus" />
+      <env name="DB_USERNAME" value="postgres" />
+      <env name="DB_PASSWORD" value="&lt;your Postgres password goes here&gt;" />
+      <env name="BASE_URL" value="http://localhost:4200" />
+      <env name="OAUTH_ORIGINS" value="http://localhost:4200,https://oengus.io SENTRY_DSN=" />
+      <env name="SENTRY_TRACES_SAMPLE_RATE" value="1.0" />
+      <env name="SENTRY_ENVIRONMENT" value="local" />
+    </envs>
+    <option name="MAIN_CLASS_NAME" value="app.oengus.OengusApplication" />
+    <module name="oengusio.main" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.idea/runConfigurations/OengusApplicationTemplate.xml
+++ b/.idea/runConfigurations/OengusApplicationTemplate.xml
@@ -3,6 +3,7 @@
     <envs>
       <env name="JWT_SECRET" value="&lt;random string&gt;" />
       <env name="PAYPAL_CLIENT_ID" value="" />
+      <env name="PAYPAL_CLIENT_SECRET" value="" />
       <env name="DISCORD_CLIENT_ID" value="&lt;your Discord client ID goes here&gt;" />
       <env name="DISCORD_CLIENT_SECRET" value="&lt;your Discord client secret goes here&gt;" />
       <env name="DISCORD_BOT_TOKEN" value="" />
@@ -24,6 +25,7 @@
       <env name="OAUTH_ORIGINS" value="http://localhost:4200,https://oengus.io SENTRY_DSN=" />
       <env name="SENTRY_TRACES_SAMPLE_RATE" value="1.0" />
       <env name="SENTRY_ENVIRONMENT" value="local" />
+      <env name="SENTRY_DSN" value="" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="app.oengus.OengusApplication" />
     <module name="oengusio.main" />

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Note that the front-end lives on this repository [https://github.com/esamarathon
 
 ## How to run on your computer
 
+_**Disclaimer**: self-hosted instances are not allowed to use the Oengus branding._
+
 ### Requirements
 
 - Java JDK 16

--- a/README.md
+++ b/README.md
@@ -63,11 +63,18 @@ SENTRY_ENVIRONMENT=local;
 
 #### Run
 
-##### Docker (recommended)
-Copy `docker-compose.yml` to `docker-compose.override.yml` and ill in the environment variables, then run `docker-compose up --build`
+##### Docker (recommended for production)
+
+Docker setup instructions are in [docs/DOCKER.md](./docs/DOCKER.md).
+
+1. Copy `docker-compose.yml` to `docker-compose.override.yml`
+2. Fill in the environment variables in `docker-compose.override.yml`
+3. Run `docker-compose up --build`
 
 ##### IDE
-Start Application.java with your favourite IDE. On first startup the database will be initialized automatically.
+
+Start `OengusApplication.java` with your favourite IDE. On first startup the database will be initialized automatically.
+See [docs/DEVELOPER.md](./docs/DEVELOPER.md) for detailed instructions on how to set up a development environment.
 
 ## Support
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -64,7 +64,7 @@ The easiest way for developers to run Oengus is from an [IntelliJ IDEA run confi
    DISCORD_CLIENT_SECRET
    DB_PASSWORD
    ```
-6. Run the configuration that you've created. The backend of Oengus should now be running in your IDE!
+6. Run the configuration that you've created. The Oengus backend should now be running in your IDE!
 
 [Discord instructions]: <https://github.com/SinisterRectus/Discordia/wiki/Setting-up-a-Discord-application>
 [IntelliJ run configs]: <https://www.jetbrains.com/help/idea/run-debug-configuration.html>

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -34,10 +34,9 @@ postgres@hostname:~$ psql
 postgres=# ALTER USER postgres PASSWORD '<your password here>';
 ```
 
-Create database `oengus`:
+Create database named `oengus` in your Postgres installation. For example, using the [`createdb` executable][createdb]:
 
 ```shell
-$ sudo su - postgres
 postgres@hostname:~$ createdb oengus
 ```
 
@@ -68,3 +67,4 @@ The easiest way for developers to run Oengus is from an [IntelliJ IDEA run confi
 
 [Discord instructions]: <https://github.com/SinisterRectus/Discordia/wiki/Setting-up-a-Discord-application>
 [IntelliJ run configs]: <https://www.jetbrains.com/help/idea/run-debug-configuration.html>
+[createdb]: <https://www.postgresql.org/docs/12/app-createdb.html>

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -42,7 +42,8 @@ postgres@hostname:~$ createdb oengus
 
 ## Discord integration
 
-Discord integration is needed to allow you to login into your Oengus dev environment of with your real Discord account.
+Discord integration is needed to allow you to login into your Oengus dev environment with your real Discord account.
+You can also use Twitch and Twitter integration, but Discord is recommended as the easiest to set up.
 
 Follow [these instructions][Discord instructions] to create a Discord client ID and client secret values. Name your
 application something like `<your name>-oengus-dev`.

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -1,33 +1,46 @@
 # Oengus developer environment
 
-This instruction provides steps on how to set up a development environment to work on Oengus backend in Ubuntu or other
-Debian-based GNU/Linux distributions. See [DOCKER.md](./DOCKER.md) for Docker instructions.
+This instruction provides steps on how to set up a development environment to work on Oengus backend.
+See [DOCKER.md](./DOCKER.md) for Docker instructions.
 
 ## Prerequisites
 
 Install packages which are needed for running Oengus. JDK 16 or later is required. Just install the latest JDK available
-in your distribution. For example, for Java 17:
+in your distribution. For example, for Java 17 on a Debian-based distro:
 
-    $ sudo apt install openjdk-17-jdk postgresql
+```shell
+$ sudo apt install openjdk-17-jdk postgresql
+```
+
+For other ways to install JDK and Postgres, see their respective websites:
+
+- JDK, e.g. [Oracle JDK](https://www.java.com/en/download/) or [OpenJDK](http://openjdk.java.net/).
+- https://www.postgresql.org/download/
 
 ## Source code
 
-    $ git clone git@github.com:esamarathon/oengusio.git
-    $ cd oengusio
+```shell
+$ git clone git@github.com:esamarathon/oengusio.git
+$ cd oengusio
+```
 
 Postgres
 --------
 
 If you haven't used Postgres before, set up a password for the connection to the database:
 
-    $ sudo su - postgres
-    postgres@hostname:~$ psql
-    postgres=# ALTER USER postgres PASSWORD '<your password here>';
+```shell
+$ sudo su - postgres
+postgres@hostname:~$ psql
+postgres=# ALTER USER postgres PASSWORD '<your password here>';
+```
 
 Create database `oengus`:
 
-    $ sudo su - postgres
-    postgres@hostname:~$ createdb oengus
+```shell
+$ sudo su - postgres
+postgres@hostname:~$ createdb oengus
+```
 
 Discord integration
 -------------------
@@ -49,9 +62,11 @@ The easiest way for developers to run Oengus is from an [IntelliJ IDEA run confi
 4. Rename the new config.
 5. Edit the environment variables to insert your own values for:
 
-       DISCORD_CLIENT_ID
-       DISCORD_CLIENT_SECRET
-       DB_PASSWORD
+   ```
+   DISCORD_CLIENT_ID
+   DISCORD_CLIENT_SECRET
+   DB_PASSWORD
+   ```
 6. Run the configuration that you've created. The backend of Oengus should now be running in your IDE!
 
 [Discord instructions]: <https://github.com/SinisterRectus/Discordia/wiki/Setting-up-a-Discord-application>

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -24,8 +24,7 @@ $ git clone git@github.com:esamarathon/oengusio.git
 $ cd oengusio
 ```
 
-Postgres
---------
+## Postgres
 
 If you haven't used Postgres before, set up a password for the connection to the database:
 
@@ -42,16 +41,14 @@ $ sudo su - postgres
 postgres@hostname:~$ createdb oengus
 ```
 
-Discord integration
--------------------
+## Discord integration
 
 Discord integration is needed to allow you to login into your Oengus dev environment of with your real Discord account.
 
 Follow [these instructions][Discord instructions] to create a Discord client ID and client secret values. Name your
 application something like `<your name>-oengus-dev`.
 
-IntelliJ IDEA run config
-------------------------
+## IntelliJ IDEA run config
 
 The easiest way for developers to run Oengus is from an [IntelliJ IDEA run configuration][IntelliJ run configs].
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -1,0 +1,58 @@
+# Oengus developer environment
+
+This instruction provides steps on how to set up a development environment to work on Oengus backend in Ubuntu or other
+Debian-based GNU/Linux distributions. See [DOCKER.md](./DOCKER.md) for Docker instructions.
+
+## Prerequisites
+
+Install packages which are needed for running Oengus. JDK 16 or later is required. Just install the latest JDK available
+in your distribution. For example, for Java 17:
+
+    $ sudo apt install openjdk-17-jdk postgresql
+
+## Source code
+
+    $ git clone git@github.com:esamarathon/oengusio.git
+    $ cd oengusio
+
+Postgres
+--------
+
+If you haven't used Postgres before, set up a password for the connection to the database:
+
+    $ sudo su - postgres
+    postgres@hostname:~$ psql
+    postgres=# ALTER USER postgres PASSWORD '<your password here>';
+
+Create database `oengus`:
+
+    $ sudo su - postgres
+    postgres@hostname:~$ createdb oengus
+
+Discord integration
+-------------------
+
+Discord integration is needed to allow you to login into your Oengus dev environment of with your real Discord account.
+
+Follow [these instructions][Discord instructions] to create a Discord client ID and client secret values. Name your
+application something like `<your name>-oengus-dev`.
+
+IntelliJ IDEA run config
+------------------------
+
+The easiest way for developers to run Oengus is from an [IntelliJ IDEA run configuration][IntelliJ run configs].
+
+1. Open the project in IntelliJ IDEA by selecting Oengus's file `build.gradle` in the "Open..." dialog.
+2. Open the "Run/Debug Configurations" dialog.
+3. Make a copy of the config `OengusApplicationTemplate` for yourself by clicking the "Copy Configuration" button above
+   the list.
+4. Rename the new config.
+5. Edit the environment variables to insert your own values for:
+
+       DISCORD_CLIENT_ID
+       DISCORD_CLIENT_SECRET
+       DB_PASSWORD
+6. Run the configuration that you've created. The backend of Oengus should now be running in your IDE!
+
+[Discord instructions]: <https://github.com/SinisterRectus/Discordia/wiki/Setting-up-a-Discord-application>
+[IntelliJ run configs]: <https://www.jetbrains.com/help/idea/run-debug-configuration.html>

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,0 +1,38 @@
+Oengus Docker instructions
+==========================
+
+To run Oengus backend for development purposes, you don't need to use Docker. Using IntelliJ IDEA for development is
+both easier and more convenient: [IntelliJ IDEA instructions](./DEVELOPER.md). However, if you do need to use the Docker
+image, follow the instruction below on how to use Oengus in Docker in Ubuntu or other Debian-based GNU/Linux
+distributions.
+
+Installation
+------------
+
+Install packages listed in "Prerequisites" section of [DEVELOPER.md](./DEVELOPER.md). As of March 2022, Ubuntu's
+docker-compose is way outdated. Because of that, you'll have to install Docker from Docker's packages:
+https://docs.docker.com/engine/install/ubuntu/
+
+Docker setup
+------------
+
+If you haven't used Docker before, you need to do the following:
+
+1. Add yourself to the `docker` group to have access to the daemon:
+
+       $ sudo usermod -a -G docker $USER
+2. To get the updated groups in text shells you can just re-log in, but in GUI shells, you'll have to re-log in via
+   their GUI.
+
+       $ sudo su - $USER
+3. Start up the docker daemon (assuming systemd-based distro):
+
+       $ sudo systemctl start docker
+
+## Get Oengus Docker image
+
+Get the Docker image of Oengus from [Docker Hub][Docker image]:
+
+    $ docker pull oengusio/backend
+
+[Docker image]: <https://hub.docker.com/repository/docker/oengusio/backend>

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,20 +1,17 @@
-Oengus Docker instructions
-==========================
+# Oengus Docker instructions
 
-To run Oengus backend for development purposes, you don't need to use Docker. Using IntelliJ IDEA for development is
+To run Oengus backend for development purposes you don't need to use Docker. We actively discourage the use of docker for development. Using IntelliJ IDEA for development is
 both easier and more convenient: [IntelliJ IDEA instructions](./DEVELOPER.md). However, if you do need to use the Docker
 image, follow the instruction below on how to use Oengus in Docker in Ubuntu or other Debian-based GNU/Linux
 distributions.
 
-Installation
-------------
+## Installation
 
 Install packages listed in "Prerequisites" section of [DEVELOPER.md](./DEVELOPER.md). As of March 2022, Ubuntu's
 docker-compose is way outdated. Because of that, you'll have to install Docker from Docker's packages:
 https://docs.docker.com/engine/install/ubuntu/
 
-Docker setup
-------------
+## Docker setup
 
 If you haven't used Docker before, you need to do the following:
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -20,19 +20,27 @@ If you haven't used Docker before, you need to do the following:
 
 1. Add yourself to the `docker` group to have access to the daemon:
 
-       $ sudo usermod -a -G docker $USER
+   ```shell
+   $ sudo usermod -a -G docker $USER
+   ```
 2. To get the updated groups in text shells you can just re-log in, but in GUI shells, you'll have to re-log in via
    their GUI.
 
-       $ sudo su - $USER
+   ```shell
+   $ sudo su - $USER
+   ```
 3. Start up the docker daemon (assuming systemd-based distro):
 
-       $ sudo systemctl start docker
+   ```shell
+   $ sudo systemctl start docker
+   ```
 
 ## Get Oengus Docker image
 
 Get the Docker image of Oengus from [Docker Hub][Docker image]:
 
-    $ docker pull oengusio/backend
+```shell
+$ docker pull oengusio/backend
+```
 
 [Docker image]: <https://hub.docker.com/repository/docker/oengusio/backend>


### PR DESCRIPTION
Document what I had to do during on-boarding for Oengus backend
development.  Link to new files from `README.md` and fix a minor issue:
point the reader to the `OengusApplication.java` file instead of just
`Application.java`.

Create a shared IntelliJ IDEA run configuration, which can be used by
developers to quickly create their own.

-----

I'm not sure what to do with section ["Instructions" in README.md](https://github.com/esamarathon/oengusio/blob/master/README.md#instructions):

1. I don't really understand why it mentions "redirect urls" – I certainly didn't need to do anything about these. [Directory `src/environments` in the frontend repository](https://github.com/esamarathon/oengus-webapp/tree/develop/src/environments) already has them in every file.
2. "Fill the following fields and add them to your environment variables" – both IntelliJ IDEA run config `OengusApplicationTemplate` and `docker-compose.yml` have the whole list, so the list in README seems redundant.